### PR TITLE
Fix for iOS builds

### DIFF
--- a/src/gplot.c
+++ b/src/gplot.c
@@ -386,6 +386,15 @@ l_int32  ignore;
     if (!gplot)
         return ERROR_INT("gplot not defined", procName, 1);
 
+#if defined (__APPLE__)
+    #include "TargetConditionals.h"
+#endif
+
+#if defined (__APPLE__) && (defined(TARGET_OS_IPHONE) || defined(OS_IOS))
+    L_ERROR("iOS does not support system()\n", procName);
+    return 1;
+#else
+
     gplotGenCommandFile(gplot);
     gplotGenDataFiles(gplot);
     cmdname = genPathname(gplot->cmdname, NULL);
@@ -399,6 +408,7 @@ l_int32  ignore;
     ignore = system(buf);  /* gnuplot || wgnuplot */
     LEPT_FREE(cmdname);
     return 0;
+#endif
 }
 
 

--- a/src/writefile.c
+++ b/src/writefile.c
@@ -863,6 +863,15 @@ char            fullpath[_MAX_PATH];
         return ERROR_INT("no program chosen for display", procName, 1);
     }
 
+#if defined (__APPLE__)
+#include "TargetConditionals.h"
+#endif
+
+#if defined (__APPLE__) && (defined(TARGET_OS_IPHONE) || defined(OS_IOS))
+    L_ERROR("iOS does not support system()\n", procName);
+    return 1;
+#else
+
         /* Display with three views if either spp = 4 or if colormapped
          * and the alpha component is not fully opaque */
     opaque = TRUE;
@@ -980,6 +989,7 @@ char            fullpath[_MAX_PATH];
     pixDestroy(&pix1);
     pixDestroy(&pix2);
     LEPT_FREE(tempname);
+#endif
     return 0;
 }
 


### PR DESCRIPTION
iOS SKDs now actively check for the use of system and will
give a compiler error if it is used. Follow approximate
method used to solve this onl latest (pending 1.77.0) leptonica -
can't cherry pick that as the code has moved.